### PR TITLE
Update ndusttypes to ndustsmall

### DIFF
--- a/src/adjust_data.f90
+++ b/src/adjust_data.f90
@@ -290,7 +290,7 @@ subroutine fake_twofluids(istart,iend,ndim,ndimV,dat,npartoftype,iamtype)
                           irho,ix,ih,ipmass,ivx,ideltav,ideltavsum
  use mem_allocation, only:alloc
  use particle_data,  only:maxpart,maxstep,maxcol
- use settings_data,  only:iverbose,ndusttypes,idustfrac_plot,ideltav_plot
+ use settings_data,  only:iverbose,ndustsmall,idustfrac_plot,ideltav_plot
  integer,                       intent(in)    :: istart,iend,ndim,ndimV
  real,    dimension(:,:,:),     intent(inout), allocatable :: dat
  integer, dimension(:,:),       intent(inout), allocatable :: npartoftype
@@ -306,7 +306,7 @@ subroutine fake_twofluids(istart,iend,ndim,ndimV,dat,npartoftype,iamtype)
     !--determine which dust fraction is being used to create the fake dust particles
     !
     !if (iverbose >= 0) print*,' got dustfrac in column ',idustfrac
-    if (ndusttypes>1) then
+    if (ndustsmall>1) then
        if (idustfrac_plot == 0 ) then
           idustfrac_temp = idustfracsum
           idustfrac_plot = idustfracsum
@@ -367,12 +367,12 @@ subroutine fake_twofluids(istart,iend,ndim,ndimV,dat,npartoftype,iamtype)
                 endif
              else
                 !--copy the dustfracion
-                dat(jdust,idustfracsum:idustfracsum+ndusttypes,i) = &
-                    dat(j,idustfracsum:idustfracsum+ndusttypes,i)
+                dat(jdust,idustfracsum:idustfracsum+ndustsmall,i) = &
+                    dat(j,idustfracsum:idustfracsum+ndustsmall,i)
                 !--copy the deltav's
                 if (ideltavsum /= 0) then
-                   dat(jdust,ideltavsum:ideltavsum+ndimV*(ndusttypes+1)-1,i) = &
-                              dat(j,ideltavsum:ideltavsum+ndimV*(ndusttypes+1)-1,i)
+                   dat(jdust,ideltavsum:ideltavsum+ndimV*(ndustsmall+1)-1,i) = &
+                              dat(j,ideltavsum:ideltavsum+ndimV*(ndustsmall+1)-1,i)
                 endif
              endif
              iamtype(ntoti + ndust,i) = 2
@@ -390,7 +390,7 @@ subroutine fake_twofluids(istart,iend,ndim,ndimV,dat,npartoftype,iamtype)
              if (use_vels) then
                 veli(:)      = dat(j,ivx:ivx+ndimV-1,i)
                 deltav(:)    = dat(j,ideltav_temp:ideltav_temp+ndimV-1,i)
-                if (ndusttypes>1 .and. idustfrac_temp/=idustfracsum) then
+                if (ndustsmall>1 .and. idustfrac_temp/=idustfracsum) then
                    deltavsum(:) = dat(j,ideltavsum:ideltavsum+ndimV-1,i)
                    vgas(:)      = veli(:) - (1. - gasfraci)*deltavsum(:)
                    vdust(:)     = veli(:) + deltav(:) - (1. - gasfraci)*deltavsum(:)

--- a/src/calc_quantities.f90
+++ b/src/calc_quantities.f90
@@ -315,7 +315,7 @@ subroutine print_example_quantities(verbose,ncalc)
  integer, intent(inout), optional :: ncalc
  logical :: prefill
  character(len=lenlabel) :: string,labelprev,ldfracsum
- integer :: i,j,ivecstart,ierr,ilen,idustfrac1,ndusttypes
+ integer :: i,j,ivecstart,ierr,ilen,idustfrac1,ndustsmall
  logical :: gotpmag,gotpressure
 
  gotpmag = .false.
@@ -359,7 +359,7 @@ subroutine print_example_quantities(verbose,ncalc)
  string = ' '
  if (irho.gt.0 .and. iutherm.gt.0) then
     gotpressure = .true.
-    if (idustfrac>0 .and. ndusttypes>1) then
+    if (idustfrac>0 .and. ndustsmall>1) then
        write(string,"(a)",iostat=ierr) &
             'pressure = (gamma-1)*(1 - '//trim(ldfracsum)//')*' &
             //trim(shortlabel(label(irho),unitslabel(irho)))//  &
@@ -381,10 +381,10 @@ subroutine print_example_quantities(verbose,ncalc)
  !
  ldfracsum = ' '
  if (idustfrac == 0) then
-    call find_repeated_tags('dustfrac',ncolumns,label,idustfrac1,ndusttypes)
-    if (ndusttypes > 1) then
+    call find_repeated_tags('dustfrac',ncolumns,label,idustfrac1,ndustsmall)
+    if (ndustsmall > 1) then
        string = 'dustfrac = '//trim(shortlabel(label(idustfrac1),unitslabel(idustfrac1)))
-       do i=idustfrac1+1,idustfrac1+ndusttypes-1
+       do i=idustfrac1+1,idustfrac1+ndustsmall-1
           string = trim(string)//'+'//(trim(shortlabel(label(i),unitslabel(i))))
        enddo
        ldfracsum = 'dustfrac'
@@ -427,8 +427,8 @@ subroutine print_example_quantities(verbose,ncalc)
        print "(11x,a)",trim(string)
     endif
     !--densities of each individual dust phase
-    if (ndusttypes > 1) then
-       do i = idustfrac1,idustfrac1+ndusttypes-1
+    if (ndustsmall > 1) then
+       do i = idustfrac1,idustfrac1+ndustsmall-1
           string = '\rho_{d,'
           call append_number(string,i-idustfrac1+1)
           string = trim(string)//'} = ' &
@@ -453,7 +453,7 @@ subroutine print_example_quantities(verbose,ncalc)
     endif
 
     if (ideltav.gt.0 .and. ivx.gt.0 .and. ndimV.gt.0) then
-       if (ndusttypes==1) then
+       if (ndustsmall==1) then
           !--gas velocities
           do i=1,ndimV
              write(string,"(a)",iostat=ierr) trim(labelvec(ivx))//'_{gas,'//trim(labelcoord(i,icoordsnew))//'} = ' &

--- a/src/globaldata.f90
+++ b/src/globaldata.f90
@@ -128,7 +128,7 @@ module settings_data
  integer :: numplot,ncalc,ncolumns,nextra
  integer :: ndataplots
  integer :: ndim, ndimv
- integer :: ndusttypes
+ integer :: ndustsmall
  integer :: idustfrac_plot = 0
  integer :: ideltav_plot = 0
  integer :: icoords,icoordsnew,iformat,ntypes,iexact

--- a/src/options_particleplots.f90
+++ b/src/options_particleplots.f90
@@ -119,7 +119,7 @@ subroutine submenu_particleplots(ichoose)
   use labels,          only:labeltype,ih,label,idustfracsum,ideltavsum
   use limits,          only:lim
   use settings_data,   only:icoords,ntypes,ndim,ndimV,UseTypeInRenderings, &
-                            ndataplots,ndusttypes,idustfrac_plot,ideltav_plot,ncalc
+                            ndataplots,ndustsmall,idustfrac_plot,ideltav_plot,ncalc
   use settings_render, only:iplotcont_nomulti
   use particle_data,   only:npartoftype,iamtype
   use prompting,       only:prompt,print_logical
@@ -218,7 +218,7 @@ subroutine submenu_particleplots(ichoose)
         elseif (.not.iplotpartoftype(itype)) then
            PlotonRenderings(itype) = .false.
         endif
-        if (trim(labeltype(itype))=='dust'.and. iplotpartoftype(itype) .and. ndusttypes>1) then
+        if (trim(labeltype(itype))=='dust'.and. iplotpartoftype(itype) .and. ndustsmall>1) then
            !--if idustfrac_plot hasn't been defined...
            if (idustfrac_plot == 0 ) then
               idustfrac_plot = idustfracsum
@@ -228,7 +228,7 @@ subroutine submenu_particleplots(ichoose)
            write(idustfracsum_string,'(I3)') idustfracsum
            call prompt('Which dust phase would you like to render? ('          &
                        //trim(adjustl(idustfracsum_string))//'=summed)',  &
-                       idustfrac_plot,idustfracsum,idustfracsum+ndusttypes)
+                       idustfrac_plot,idustfracsum,idustfracsum+ndustsmall)
            !--update which set of deltav's will be used
            ideltav_plot = ideltavsum + ndimV*(idustfrac_plot - idustfracsum)
            if (idustfrac_prev /= idustfrac_plot) then

--- a/src/plotstep.f90
+++ b/src/plotstep.f90
@@ -89,7 +89,7 @@ subroutine initialise_plotting(ipicky,ipickx,irender_nomulti,icontour_nomulti,iv
   use titles,             only:read_titles,read_steplegend
   use settings_data,      only:ndim,ndimV,numplot,ncolumns,ncalc,ndataplots,required,   &
                                icoords,icoordsnew,debugmode,ntypes,usetypeinrenderings, &
-                               ndusttypes,idustfrac_plot,ideltav_plot,fakedust
+                               ndustsmall,idustfrac_plot,ideltav_plot,fakedust
   use settings_page,      only:nacross,ndown,ipapersize,tile,papersizex,aspectratio,&
                                iPageColours,iadapt,iadaptcoords,linewidth,linepalette,device,nomenu,&
                                interactive,ipapersizeunits,usecolumnorder,colourpalette,maxc
@@ -546,7 +546,7 @@ subroutine initialise_plotting(ipicky,ipickx,irender_nomulti,icontour_nomulti,iv
         !--dependencies for density
         !
         if (required(irho)) then
-           if (ndusttypes>1) then
+           if (ndustsmall>1) then
               required(idustfracsum) = .true.
               required(idustfrac_plot) = .true.
            else
@@ -557,7 +557,7 @@ subroutine initialise_plotting(ipicky,ipickx,irender_nomulti,icontour_nomulti,iv
         !--dependencies for velocity
         !
         if (any(required(ivx:ivx+ndimV-1))) then
-           if (ndusttypes>1) then
+           if (ndustsmall>1) then
               required(irho) = .true.
               required(idustfracsum) = .true.
               required(idustfrac_plot) = .true.

--- a/src/read_data_sphNG.f90
+++ b/src/read_data_sphNG.f90
@@ -2472,7 +2472,7 @@ subroutine set_labels
      labeltype(5) = 'star'
      labeltype(6) = 'unknown/dead'
      UseTypeInRenderings(1) = .true.
-     UseTypeInRenderings(2) = .false.
+     UseTypeInRenderings(2) = .true.
      UseTypeInRenderings(3) = .true.
      UseTypeInRenderings(4) = .false.
      UseTypeInRenderings(5) = .true.


### PR DESCRIPTION
The new ndustsmall tag is incompatible with the ndusttypes in Splash. Since these new tags (ndustsmall and ndustlarge) look like they will persist for a long time, I figured it would be better to change the variable name in Splash to conform to the new style. There is an if statement to look for ndusttypes for backwards compatibility.