### PR TITLE
(hdf5) fixed compiler error when HDF5=yes

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -64,8 +64,8 @@ endif
 # If you need the HDF5 libraries, edit the lines below
 # possibly adding a -L/libpath/ and a -I/includepath/
 #
-HDF5LIBS    = -L/usr/lib/x86_64-linux-gnu/hdf5/serial/ -lhdf5
-HDF5INCLUDE = -I/usr/include/hdf5/serial/
+HDF5LIBS    = -L$(HDF5ROOT)/lib -lhdf5
+HDF5INCLUDE = -I$(HDF5ROOT)/include
 H5PART_LIBS    = -L$(H5PART_DIR)/lib -lH5Part
 H5PART_INCLUDE = -I$(H5PART_DIR)/include
 ifdef FITS_DIR

--- a/src/read_data_flash_hdf5.f90
+++ b/src/read_data_flash_hdf5.f90
@@ -46,13 +46,13 @@
 ! in the module 'particle_data'
 !-------------------------------------------------------------------------
 module flash_hdf5read
- use, intrinsic :: iso_c_binding, only:c_int,c_float,c_char
+ use, intrinsic :: iso_c_binding, only:c_int,c_double,c_char
  !interface to the c versions
  interface
   subroutine read_flash_hdf5_header(filename,time,npart,ncol,ierr) bind(c)
    import
    character(kind=c_char,len=1), intent(in) :: filename
-   real(kind=c_float), intent(out) :: time
+   real(kind=c_double), intent(out) :: time
    integer(kind=c_int), intent(out) :: npart,ncol,ierr
   end subroutine read_flash_hdf5_header
 
@@ -102,10 +102,10 @@ end module flash_hdf5read
 
 module readdata_flash_hdf5
  implicit none
- 
+
  public :: read_data_flash_hdf5, set_labels_flash_hdf5
- 
- private 
+
+ private
 contains
 
 subroutine read_data_flash_hdf5(dumpfile,indexstart,ipos,nstepsread)


### PR DESCRIPTION
- type of `time` in `read_flash_hdf5_header()` needs to be `c_double` since splash is double precision by default
- removed hardcoded `HDF5ROOT` in Makefile. Target `checkhdf5` already ensures that `HDF5ROOT` is defined/set before compiling