### PR TITLE
Prevent plotting of Phantom's dead sinks

### DIFF
--- a/src/options_particleplots.f90
+++ b/src/options_particleplots.f90
@@ -255,7 +255,7 @@ subroutine submenu_particleplots(ichoose)
            '  1 = foreground ',&
            '  2->10 = various colours (see default colour indices for plot library)'
     over_types3: do itype=1,ntypes
-       if (all(npartoftype(itype,:) == 0)) cycle over_types3
+       if (all(npartoftype(itype,:) == 0) .and. itype/=isinktype) cycle over_types3
        call prompt(' Enter default colour for '//trim(labeltype(itype)) &
                 //' particles:',idefaultcolourtype(itype),-1,14)
     enddo over_types3

--- a/src/particleplot.f90
+++ b/src/particleplot.f90
@@ -464,6 +464,8 @@ subroutine plot_particle(imarktype,x,y,h)
  integer :: imarker
  real    :: size
 
+ if (h < 0.) return ! this will prevent plotting of merged sinks in Phantom
+
  select case(imarktype)
  case(32:35)
     imarker = imarktype - 31

--- a/src/read_data_sphNG.f90
+++ b/src/read_data_sphNG.f90
@@ -1225,6 +1225,23 @@ endif
 end subroutine get_rho_from_h
 
 !----------------------------------------------------------------------
+!  Set a negative smoothing length for merged sinks, so that
+!  they can be ignored when plotting
+!----------------------------------------------------------------------
+subroutine set_sink_merged(i1,i2,ih,ipmass,dat)
+ integer, intent(in) :: i1,i2,ih,ipmass
+ real, intent(inout) :: dat(:,:)
+ integer :: i
+
+ if (ih > 0 .and. ipmass > 0) then
+    do i=i1,i2
+       if (dat(i,ipmass) < 0.) dat(i,ih) = -1.
+    enddo
+ endif
+
+end subroutine set_sink_merged
+
+!----------------------------------------------------------------------
 !  Set density on sink particles based on the mass and radius
 !  this is useful for opacity rendering, but also provides useful
 !  information rather than just having zero density on sinks
@@ -1901,6 +1918,8 @@ subroutine read_data_sphNG(rootname,indexstart,iposn,nstepsread)
                       endif
                    enddo
                 endif
+                ! PSEUDO-remove accreted sinks
+                call set_sink_merged(npart+1,int(npart+isize(iarr)),ih,ipmass,dat(:,:,j))
                 ! DEFINE density on sink particles (needed for opacity rendering)
                 if (required(irho)) call set_sink_density(npart+1,int(npart+isize(iarr)),ih,ipmass,irho,dat(:,:,j))
                 npart  = npart + isize(iarr)


### PR DESCRIPTION
Phantom can now merge sinks; one sink absorbs the properties of the other and the other is given negative mass.  This commit will prevent plotting the dead sink with negative mass.