### PR TITLE
Limits: added new option for a centred cube

### DIFF
--- a/src/options_limits.f90
+++ b/src/options_limits.f90
@@ -64,7 +64,7 @@ subroutine submenu_limits(ichoose)
  integer, intent(in) :: ichoose
  integer             :: iaction,ipick,i,index,ierr
  integer             :: itracktypeprev,itrackoffsetprev
- character(len=120)  :: transprompt
+ character(len=120)  :: transprompt,fmtstring
  character(len=12)   :: string,string2
  character(len=20)   :: pstring,pstring2
 
@@ -130,8 +130,19 @@ subroutine submenu_limits(ichoose)
     do while (ipick > 0)
        ipick = 0
        !write(*,*)
-       call prompt('Enter column number to set limits (0=quit)',ipick,0,numplot)
-       if (ipick > 0) then
+       write(fmtstring,'(a,I4,a)') 'Enter column number to set limits (0=quit;',numplot+1,'=centred cube in xyz)'
+       call prompt(trim(fmtstring),ipick,0,numplot+1)
+       if (ipick==numplot+1) then
+          call prompt('xy'//trim(label(3))//' max ',lim(3,2))
+          lim(1,2) =  lim(3,2)
+          lim(2,2) =  lim(3,2)
+          lim(1,1) = -lim(3,2)
+          lim(2,1) = -lim(3,2)
+          lim(3,1) = -lim(3,2)
+          print*,'>> '//trim(label(1))//' limits set (min,max) = ',lim(1,1),lim(1,2)
+          print*,'>> '//trim(label(2))//' limits set (min,max) = ',lim(2,1),lim(2,2)
+          print*,'>> '//trim(label(3))//' limits set (min,max) = ',lim(3,1),lim(3,2)
+       elseif (ipick > 0) then
           call prompt(trim(label(ipick))//' min ',lim(ipick,1))
           call prompt(trim(label(ipick))//' max ',lim(ipick,2))
           print*,'>> '//trim(label(ipick))//' limits set (min,max) = ',lim(ipick,1),lim(ipick,2)


### PR DESCRIPTION
Currently, to set the limits to plot a centred square or cubic regions, we must manually change each individual limit.  This can be tedious during analysis when trying to determine the optimal size, or when we are constantly switching between selected sizes. 

This commit adds a new option (numplot+1) where the user enters xyz_max, and the limits are automatically set such that
x_max = xyz_max
y_max = xyz_max
z_max = xyz_max
x_min = -xyz_max
y_min = -xyz_max
z_min = -xyz_max