### PR TITLE
dynamic column matching + vtk data read

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -357,7 +357,7 @@ READFILES= read_data_ascii.f90           read_data_sphNG.f90     read_data_ndspm
            read_data_gadget_jsb.f90      read_data_foulkes.f90   read_data_jjm.f90 \
            read_data_jjm_multiphase.f90  read_data_mbate.f90     read_data_oilonwater.f90 \
            read_data_rsph.f90            read_data_urban.f90     read_data_spyros.f90 \
-           read_data_vanaverbeke.f90
+           read_data_vanaverbeke.f90     read_data_vtk.f90
 
 READFILES_HDF5= hdf5_helper_utils.c            read_data_gadget_hdf5_utils.c   read_data_gadget_hdf5.f90 \
                 read_data_amuse_hdf5_utils.c    read_data_amuse_hdf5.f90  \

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ copyright = '2004-2023 Daniel Price and contributors'
 author = 'Daniel Price'
 
 # The full version, including alpha/beta/rc tags
-release = 'v3.8.5'
+release = 'v3.9.0'
 
 # -- General configuration ---------------------------------------------------
 

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -157,10 +157,10 @@ from formatted (ascii) output.
 
 A standard ``make`` will create a binary which supports the file formats listed in
 :ref:`tab:defaultreads`, plus a bunch of others (type ``splash --formats`` to see what formats your build supports).
-All data formats in the splash repository that do not have additional dependencies (e.g. ``HDF5``) will be
-supported in the splash binary as of version ``3.0.0``.
+All data formats are supported in the splash binary by default unless there 
+are external library dependencies (e.g. ``HDF5``) .
 
-In many cases, the format of the file can be successfully guessed from the file header, so you can simply type::
+The format of the file can in many cases be successfully guessed from the file extension or header, so you can simply type::
 
 	splash disc_00000
 
@@ -169,20 +169,12 @@ the following will read a phantom dumpfile::
 
 	splash --format phantom disc_00000
 
-This will automatically recognise a Phantom binary dumpfile. For backwards compatibility with
-previous version of ``splash``, one can add aliases into their `.bashrc`, or equivalent::
+For backwards compatibility with previous version of ``splash``, one can add aliases into their `.bashrc`, or equivalent::
 
    alias asplash='splash ' # Alias for ascii splash
    alias ssplash='splash -f phantom '
    alias gsplash='splash -f gadget '
-   alias vsplash='splash -f vine '
-   alias nsplash='splash -f ndspmhd '
-   alias rsplash='splash -f srosph '
-   alias dsplash='splash -f dragon '
-   alias srsplash='splash -f seren '
    alias tsplash='splash -f tipsy '
-   alias tsplash='splash -f tipsy '
-   alias msplash='splash -f mhutch '
 
 If splash is compiled with ``HDF5=yes``, the formats listed in :ref:`tab:hdf5reads` will also be available in the ``splash`` binary.
 Other supported formats are listed in :ref:`tab:otherreads`, but these require additional libraries.
@@ -193,7 +185,7 @@ Other supported formats are listed in :ref:`tab:otherreads`, but these require a
    +------------------------------+----------------------------+-------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
    | ``splash`` command           | Format Read                | ``read_data`` File            |  Comments                                                                                                                                                                                                                                         |
    +==============================+============================+===============================+===================================================================================================================================================================================================================================================+
-   | ``splash -ascii <file>``     | ascii                      | ``read_data_ascii.f90``        | Generic data read for n-column ascii formats. Automatically  determines number of columns and skips header lines. Can recognise SPH particle data based on the column labels. Use ``splash -e`` to plot non-SPH data (e.g.  energy vs time files).|
+   | ``splash -ascii <file>``     | ascii, csv                 | ``read_data_ascii.f90``       | Generic data read for n-column ascii formats. Automatically determines number of columns and skips header lines. Can recognise SPH particle data based on the column labels. Use ``splash -e`` to plot non-SPH data (e.g.  energy vs time files)  |
    +------------------------------+----------------------------+-------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
    | ``splash -dragon <file>``    | dragon                     | ``read_data_dragon``          | See environment variable  options.                                                                                                                                                                                                                |
    +------------------------------+----------------------------+-------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
@@ -207,11 +199,13 @@ Other supported formats are listed in :ref:`tab:otherreads`, but these require a
    +------------------------------+----------------------------+-------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
    | ``splash -seren <file>``     | seren                      | ``read_data_seren.f90``       | The SEREN SPH code (Hubber, McLeod et  al.)                                                                                                                                                                                                       |
    +------------------------------+----------------------------+-------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-   | ``splash -gasoline <file>``  | gasoline, tipsy            | ``read_data_tipsy.f90``       | Reads both binary and ascii TIPSY files (determined  automatically). Option ``-tipsy`` also  works.                                                                                                                                               |
+   | ``splash -gasoline <file>``  | gasoline, tipsy            | ``read_data_tipsy.f90``       | Reads both binary and ascii TIPSY files (determined automatically). Option ``-tipsy`` also  works.                                                                                                                                                |
    +------------------------------+----------------------------+-------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
    | ``splash -vine <file>``      | vine                       | ``read_data_fine.f90``        | See environment variable  options.                                                                                                                                                                                                                |
    +------------------------------+----------------------------+-------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
    |``splash -starsmasher <file>``| StarSmasher                | ``read_data_starsmasher.f90`` | The `StarSmasher <http://jalombar.github.io/starsmasher/>`_ code (Gaburov et al. 2018)                                                                                                                                                            |
+   +------------------------------+----------------------------+-------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+   | ``splash file.vtk``          | vtk legacy binary          | ``read_data_vtk.f90``         | VTK legacy binary format, e.g. from Shamrock code                                                                                                                                                                                                 |
    +------------------------------+----------------------------+-------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
 Below is a list of the supported data formats that require ``HDF5``.
@@ -252,7 +246,7 @@ Below is a list of other formats supported, but have additional library requirem
    +---------------------------+--------------+--------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
    | ``splash -h5part <file>`` | H5Part Files | ``read_data_h5part.f90`` | Requires the H5Part and HDF5 libraries. Compile ``splash`` with ``H5PART_DIR=/path/to/h5part/``.                                                                           |
    +---------------------------+--------------+--------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-   | ``splash -fits <file>``   | FITS files   | ``read_data_fits.f90``   | Requires FITS libraries. Try to compile ``splash`` with ``FITS=yes``. If this does not work, point to the location of your fits libraries with ``FITS_DIR=/path/to/fits``. |
+   | ``splash file.fits``      | FITS files   | ``read_data_fits.f90``   | Requires FITS libraries. Try to compile ``splash`` with ``FITS=yes``. If this does not work, point to the location of your fits libraries with ``FITS_DIR=/path/to/fits``. |
    +---------------------------+--------------+--------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
 
@@ -509,7 +503,7 @@ GADGET data read
 For the GADGET read (``splash -f gadget`` or just ``splash``) the options are:
 
 +-----------------------------------+-----------------------------------+
-| ``--format=2``                    | if set = 2, reads the block       |
+| ``--format=2``                    | if set = 2, force read of block   |
 |                                   | labelled GADGET format instead of |
 |                                   | the default (non block labelled)  |
 |                                   | format.                           |
@@ -592,9 +586,8 @@ For the VINE read (``splash -vine``) the options are:
 |                                   | length).                          |
 +-----------------------------------+-----------------------------------+
 | ``--mhd``                         | if set, reads VINE                |
-|                                   | dumps containing MHD arrays (note |
-|                                   | that setting VINE_MHD also        |
-|                                   | works).                           |
+|                                   | dumps containing MHD arrays       |
+|                                   | (or set VINE_MHD=yes)             |
 +-----------------------------------+-----------------------------------+
 
 Phantom/sphNG data read

--- a/src/asciiutils.f90
+++ b/src/asciiutils.f90
@@ -32,7 +32,7 @@
 !---------------------------------------------------------------------------
 module asciiutils
  implicit none
- public :: read_asciifile,get_ncolumns,get_nrows,ncolumnsline,safename,basename
+ public :: read_asciifile,get_ncolumns,get_nrows,ncolumnsline,safename,basename,numfromfile
  public :: cstring,fstring,add_escape_chars
  public :: string_replace, string_delete, nheaderlines, string_sub
  public :: ucase,lcase,strip

--- a/src/get_data.f90
+++ b/src/get_data.f90
@@ -304,8 +304,6 @@ subroutine get_data(ireadfile,gotfilenames,firsttime,iposinfile)
     endif
  endif
 
-
- return
 end subroutine get_data
 
 !----------------------------------------------------------------------
@@ -352,14 +350,15 @@ end subroutine get_labels
 !----------------------------------------------------------------------
 subroutine rescale_data(firsttime,nsteps_read)
  use filenames,      only:unitsfile
- use labels,         only:label,unitslabel,unitslabel_default,labelzintegration,labelzintegration_default
+ use labels,         only:label,unitslabel,unitslabel_default,labelzintegration,labelzintegration_default,&
+                          check_for_shifted_column
  use settings_data,  only:ncolumns,iRescale,idefaults_file_read,iverbose,debugmode,enforce_code_units
  use settings_units, only:units,units_default,unitzintegration,unitzintegration_default,read_unitsfile
  use particle_data,  only:maxcol,dat,time
  use params,         only:maxplot
  logical, intent(in) :: firsttime
  integer, intent(in) :: nsteps_read
- integer :: i,ierr
+ integer :: i,j,icol,ierr
 
  !
  ! turn physical units on by default if:
@@ -384,10 +383,14 @@ subroutine rescale_data(firsttime,nsteps_read)
  !
  if (iRescale .and. any(abs(units(0:ncolumns)-1.0) > tiny(units))) then
     if (debugmode) write(*,"(a)") ' rescaling data...'
-    do i=1,min(ncolumns,maxcol)
-       if (abs(units(i)-1.0) > tiny(units) .and. abs(units(i)) > tiny(units)) then
-          dat(:,i,1:nsteps_read) = dat(:,i,1:nsteps_read)*units(i)
-       endif
+    do j=1,nsteps_read
+       do i=1,min(ncolumns,maxcol)
+          icol = i
+          call check_for_shifted_column(icol,iRescale)
+          if (abs(units(i)-1.0) > tiny(units) .and. abs(units(i)) > tiny(units)) then
+             dat(:,i,j) = dat(:,i,j)*units(icol)
+          endif
+       enddo
     enddo
     do i=1,nsteps_read
        if (time(i) > -0.5*huge(0.)) time(i) = time(i)*units(0)

--- a/src/get_data.f90
+++ b/src/get_data.f90
@@ -390,12 +390,11 @@ subroutine rescale_data(firsttime,nsteps_read)
  if (iRescale .and. any(abs(units(0:ncolumns)-1.0) > tiny(units))) then
     if (debugmode) write(*,"(a)") ' rescaling data...'
     imap = map_shifted_columns()
-    print*,' imap = ',imap(1:12)
     do j=1,nsteps_read
        do i=1,min(ncolumns,maxcol)
           icol = imap(i)
           !print*,i,' imap=',icol
-          if (icol /= i) print*,' shift data WAS ',i,units(i),unitslabel(i),' USING ',icol,units(icol),unitslabel(icol)
+          !if (icol /= i) print*,' shift data WAS ',i,units(i),unitslabel(i),' USING ',icol,units(icol),unitslabel(icol)
           if (abs(units(icol)-1.0) > tiny(units) .and. abs(units(icol)) > tiny(units)) then
              dat(:,i,j) = dat(:,i,j)*units(icol)
           endif

--- a/src/labels.f90
+++ b/src/labels.f90
@@ -585,19 +585,30 @@ subroutine check_for_shifted_column(icol,iRescale)
     if (inew > 0) then
        print "(1x,a,i3)",': found '//trim(shortlabel(label(inew),unitslabel(inew)))&
              //' in col ',inew
-       !
-       ! a bigger problem is that the units have changed... and the data is already rescaled
-       ! here we can at least fix the units label so it is the right one
-       !
-       if (iRescale) then
-          label(inew) = trim(labelreq(icol))//trim(unitslabel(icol))
-          unitslabel(inew) = unitslabel(icol)
-       endif
        icol = inew
     endif
  endif
 
 end subroutine check_for_shifted_column
+
+function map_shifted_columns() result(imap)
+ integer :: imap(maxplot)
+ integer :: i,icol
+
+ do i=1,size(imap)
+    imap(i) = i
+ enddo
+
+ do i=1,size(imap)
+    icol = i
+    if (len_trim(label(i)) > 0) call check_for_shifted_column(icol,.true.)
+    if (icol /= i) then
+     print*,i,' setting imap=',icol
+       imap(icol) = i
+    endif
+ enddo
+
+end function map_shifted_columns
 
 !subroutine check_for_shifted_columns(icols,shifted)
 

--- a/src/labels.f90
+++ b/src/labels.f90
@@ -610,6 +610,36 @@ function map_shifted_columns() result(imap)
 
 end function map_shifted_columns
 
+!-----------------------------------------------------------------
+!
+!  set labels for columns which have been tagged as vectors
+!  using the iamvec label
+!
+!-----------------------------------------------------------------
+subroutine set_vector_labels(ncolumns,ndimV,iamveci,labelveci,labeli,labelcoordi)
+ integer,                 intent(in)    :: ncolumns,ndimV
+ integer,                 intent(inout) :: iamveci(:)
+ character(len=*),        intent(in)    :: labelcoordi(:)
+ character(len=lenlabel), intent(inout) :: labelveci(:),labeli(:)
+ character(len=lenlabel) :: tmplabel
+ integer :: i
+ !
+ !--set labels for vector quantities
+ !
+ i = 1
+ do while (i <= ncolumns)
+    if (iamvec(i) > 0) then
+       tmplabel = labeli(i)
+       call make_vector_label(tmplabel,i,ndimV,iamveci,labelveci,labeli,labelcoordi)
+       i = i + ndimV
+    else
+       i = i + 1
+    endif
+ enddo
+
+end subroutine set_vector_labels
+
+
 !subroutine check_for_shifted_columns(icols,shifted)
 
 !end subroutine check_for_shifted_columns

--- a/src/labels.f90
+++ b/src/labels.f90
@@ -557,10 +557,10 @@ subroutine set_required_labels(required)
     endif
  enddo
 
- print*,'DEBUG: required labels:'
- do icol=1,nreq
-    if (len_trim(labelreq(icol)) > 0) print*,trim(labelreq(icol))
- enddo
+ !print*,'DEBUG: required labels:'
+ !do icol=1,nreq
+ !   if (len_trim(labelreq(icol)) > 0) print*,trim(labelreq(icol))
+ !enddo
 
 end subroutine set_required_labels
 
@@ -569,28 +569,39 @@ end subroutine set_required_labels
 !  see if a column has shifted in the actual data
 !
 !-----------------------------------------------------------------
-subroutine check_for_shifted_column(icol,iRescale)
+integer function check_for_shifted_column(icol,labelnew) result(inew)
  use asciiutils, only:match_tag
- integer, intent(inout) :: icol
+ integer, intent(in) :: icol
+ character(len=*), intent(out), optional :: labelnew
  character(len=lenlabel) :: labelcol
- logical, intent(in) :: iRescale
- integer :: inew
 
+ inew = icol
  labelcol = shortlabel(label(icol),unitslabel(icol))
 
  if (trim(labelcol) /= trim(labelreq(icol)) .and. len_trim(labelreq(icol)) > 0) then
-    write(*,"(1x,a,i3,a)",advance='no') 'column ',icol,' has shifted: was '//&
+    if (.not.present(labelnew)) write(*,"(1x,a,i3,a)",advance='no') 'column ',icol,' has shifted: was '//&
           trim(labelreq(icol))//' but got '//trim(labelcol)
     inew = match_tag(shortlabel(label(1:maxplot),unitslabel(1:maxplot)),labelreq(icol))
     if (inew > 0) then
-       print "(1x,a,i3)",': found '//trim(shortlabel(label(inew),unitslabel(inew)))&
-             //' in col ',inew
-       icol = inew
+       if (present(labelnew)) then
+          labelnew = trim(shortlabel(label(inew),unitslabel(inew)))//trim(unitslabel(icol))
+       else
+          print "(1x,a,i3)",': found '//trim(shortlabel(label(inew),unitslabel(inew)))//' in col ',inew
+       endif
+    else
+       inew = icol
     endif
  endif
 
-end subroutine check_for_shifted_column
+end function check_for_shifted_column
 
+!-----------------------------------------------------------------
+!
+!  compute the backwards map from inew -> icol based on where
+!  a column has been shifted to. This enables lookup of original
+!  units etc which can be used to scale the data
+!
+!-----------------------------------------------------------------
 function map_shifted_columns() result(imap)
  integer :: imap(maxplot)
  integer :: i,icol
@@ -601,9 +612,9 @@ function map_shifted_columns() result(imap)
 
  do i=1,size(imap)
     icol = i
-    if (len_trim(label(i)) > 0) call check_for_shifted_column(icol,.true.)
+    if (len_trim(label(i)) > 0) icol = check_for_shifted_column(i)
     if (icol /= i) then
-     print*,i,' setting imap=',icol
+       !print*,i,' setting imap=',icol
        imap(icol) = i
     endif
  enddo
@@ -638,10 +649,5 @@ subroutine set_vector_labels(ncolumns,ndimV,iamveci,labelveci,labeli,labelcoordi
  enddo
 
 end subroutine set_vector_labels
-
-
-!subroutine check_for_shifted_columns(icols,shifted)
-
-!end subroutine check_for_shifted_columns
 
 end module labels

--- a/src/plotstep.f90
+++ b/src/plotstep.f90
@@ -3264,7 +3264,7 @@ subroutine legends_and_title
  !--plot time on plot
  if (iPlotLegend .and. nyplot==1 &
         .and. ipanelselect(iPlotLegendOnlyOnPanel,ipanel,irow,icolumn) &
-        .and. timei > -0.5*huge(timei)) then  ! but not if time has not been read from dump
+        .and. (timei > -0.5*huge(timei) .or. index(legendtext,'%') > 0)) then  ! but not if time has not been read from dump
 
     !--change to background colour index for legend text if overlaid
     if (iUseBackGroundColourForAxes .and. vposlegend > 0.) then

--- a/src/plotstep.f90
+++ b/src/plotstep.f90
@@ -737,7 +737,7 @@ subroutine plotstep(ipos,istep,istepsonpage,irender_nomulti,icontour_nomulti,ive
  logical, dimension(maxparttypes) :: iusetype
 
  integer :: ntoti,iz,iseqpos,itrackpart
- integer :: i,j,k,icolumn,irow
+ integer :: i,j,k,icolumn,irow,ix_map,iy_map,irender_map,icontour_map
  integer :: nyplot,nframesloop
  integer :: irenderpart,icolours_temp
  integer :: npixyvec,nfreqpts,ipixxsec
@@ -997,7 +997,6 @@ subroutine plotstep(ipos,istep,istepsonpage,irender_nomulti,icontour_nomulti,ive
           icontourplot = 0
        endif
 
-       call check_for_shifted_column(iploty,iRescale)
        !--flag to indicate that we have actually got the contoured quantity,
        !  set to true once interpolation has been done.
        if (.not.interactivereplot .or. irerender) gotcontours = .false.
@@ -1075,7 +1074,9 @@ subroutine plotstep(ipos,istep,istepsonpage,irender_nomulti,icontour_nomulti,ive
                 print*,'ERROR: Internal error with out-of-bounds y column = ',iploty
                 exit over_plots
              endif
-             yplot(1:ntoti) = dat(1:ntoti,iploty)
+             iy_map = iploty
+             call check_for_shifted_column(iy_map,iRescale)
+             yplot(1:ntoti) = dat(1:ntoti,iy_map)
              iamvecy = iamvec(iploty)
           else
              iamvecy = 0

--- a/src/plotstep.f90
+++ b/src/plotstep.f90
@@ -83,7 +83,8 @@ subroutine initialise_plotting(ipicky,ipickx,irender_nomulti,icontour_nomulti,iv
  use colours,            only:colour_set
  use colourbar,          only:barisvertical
  use labels,             only:label,ipowerspec,ih,ipmass,irho,ikappa,iamvec,isurfdens, &
-                               is_coord,itoomre,iutherm,ipdf,ix,icolpixmap,get_z_dir,unitslabel
+                               is_coord,itoomre,iutherm,ipdf,ix,icolpixmap,get_z_dir,&
+                               unitslabel,set_required_labels
  use limits,             only:lim,rangeset,limits_are_equal
  use multiplot,          only:multiplotx,multiploty,irendermulti,icontourmulti, &
                                nyplotmulti,x_secmulti,ivecplotmulti
@@ -548,7 +549,7 @@ subroutine initialise_plotting(ipicky,ipickx,irender_nomulti,icontour_nomulti,iv
  endif
  call get_adjust_data_dependencies(required)
 
-!  endif
+ call set_required_labels(required)
  if (debugmode) print*,'DEBUG: required(1:ncolumns) = ',required(1:ncolumns+ncalc)
 
  !!--read step titles (don't need to store ntitles for this)
@@ -657,7 +658,8 @@ subroutine plotstep(ipos,istep,istepsonpage,irender_nomulti,icontour_nomulti,ive
                                ipowerspec,isurfdens,itoomre,ispsound,iutherm, &
                                ipdf,icolpixmap,is_coord,labeltype, &
                                labelzintegration,unitslabel,integrate_label, &
-                               get_sink_type,get_unitlabel_coldens,ikappa
+                               get_sink_type,get_unitlabel_coldens,ikappa,&
+                               check_for_shifted_column,labelorig
  use limits,             only:lim,get_particle_subset,lim2,lim2set
  use multiplot,          only:multiplotx,multiploty,irendermulti,ivecplotmulti, &
                                itrans,icontourmulti,x_secmulti,xsecposmulti,&
@@ -994,6 +996,8 @@ subroutine plotstep(ipos,istep,istepsonpage,irender_nomulti,icontour_nomulti,ive
           !  (because this can be achieved by rendering with colour scheme 0)
           icontourplot = 0
        endif
+
+       call check_for_shifted_column(iploty,iRescale)
        !--flag to indicate that we have actually got the contoured quantity,
        !  set to true once interpolation has been done.
        if (.not.interactivereplot .or. irerender) gotcontours = .false.
@@ -2876,6 +2880,11 @@ subroutine plotstep(ipos,istep,istepsonpage,irender_nomulti,icontour_nomulti,ive
     if (allocated(datpixcont)) deallocate(datpixcont)
     if (allocated(datpixcont3D)) deallocate(datpixcont3D)
  endif
+
+ !if (.not.interactivereplot) then
+    ! restore original labels...
+    label = labelorig
+ !endif
 
  !--free temporary arrays
  if (allocated(xplot)) deallocate(xplot)

--- a/src/read_data.F90
+++ b/src/read_data.F90
@@ -15,7 +15,7 @@
 !  a) You must cause the modified files to carry prominent notices
 !     stating that you changed the files and the date of any change.
 !
-!  Copyright (C) 2005-2020 Daniel Price. All rights reserved.
+!  Copyright (C) 2005-2023 Daniel Price. All rights reserved.
 !  Contact: daniel.price@monash.edu
 !
 !-----------------------------------------------------------------
@@ -355,23 +355,24 @@ subroutine print_available_formats(string)
  if (string == 'short') then
     print "(/,a,/)",'Example data formats (type --formats for full list):'
  else
-    print "(/,a,/)",'Supported data formats:'
+    print "(/,a,/)",'Supported data formats (auto = automatically identified from file contents):'
  endif
  print "(a)"  ,' -ascii,-csv          : ascii text/csv format (default)'
- print "(a)"  ,' -phantom -sphng      : Phantom and sphNG codes'
- print "(a)"  ,' -ndspmhd             : ndspmhd code'
+ print "(a)"  ,' -phantom -sphng      : Phantom and sphNG codes (auto)'
+ print "(a)"  ,' -vtk                 : vtk legacy binary format (auto)'
+ print "(a)"  ,' -ndspmhd             : ndspmhd code (auto)'
  print "(a)"  ,' -gandalf,-seren      : Gandalf/Seren code'
 #ifdef HDF5
- print "(a)"  ,' -gadget -gadget_hdf5 : Gadget code'
+ print "(a)"  ,' -gadget -gadget_hdf5 : Gadget code (auto)'
  print "(a)"  ,' -falcon -falcon_hdf5 : FalcON code'
  print "(a)"  ,' -flash  -flash_hdf5  : FLASH code'
  print "(a)"  ,' -cactus -cactus_hdf5 : Cactus code'
  print "(a,/)",' -amuse  -amuse_hdf5  : AMUSE Framework'
 #else
- print "(a)"  ,' -gadget              : Gadget code'
+ print "(a)"  ,' -gadget              : Gadget code (auto)'
 #endif
 #ifdef FITS
- print "(a)"  ,' -fits                : FITS format'
+ print "(a)"  ,' -fits                : FITS format (auto)'
 #endif
 #ifdef PBOB_DIR
  print "(a)"  ,' -pbob                : PBOB format'
@@ -381,7 +382,7 @@ subroutine print_available_formats(string)
 #endif
 
  if (string /= 'short') then
-    print "(a)",' -tipsy -gasoline     : Gasoline code'
+    print "(a)",' -tipsy -gasoline     : Gasoline code (auto)'
     print "(a)",' -vine                : VINE SPH code'
     print "(a)",' -rsph                : Regularised SPH'
     print "(a)",' -starsmasher         : Star Smasher code'

--- a/src/read_data.F90
+++ b/src/read_data.F90
@@ -53,6 +53,7 @@ module readdata
  use readdata_spyros,       only:read_data_spyros,       set_labels_spyros
  use readdata_urban,        only:read_data_urban,        set_labels_urban
  use readdata_starsmasher,  only:read_data_starsmasher,  set_labels_starsmasher
+ use readdata_vtk,          only:read_data_vtk,          set_labels_vtk
 
  ! Make hdf5 fortran/c modules available if compiled with hdf5
 #ifdef HDF5
@@ -282,6 +283,10 @@ subroutine select_data_format(string_in,ierr)
    read_data=> read_data_starsmasher
    set_labels=>set_labels_starsmasher
 
+ case('vtk')
+   read_data=> read_data_vtk
+   set_labels=>set_labels_vtk
+
  ! Make the hdf5 data formats available if SPLASH has been compiled with HDF5
 #ifdef HDF5
  case('phantom_hdf5', 'sphng_hdf5', 'phantomsph_hdf5')
@@ -448,6 +453,8 @@ subroutine guess_format(nfiles,filenames,ierr,informat)
     endif
  elseif (any((index(extensions, '.fits') > 0))) then
     call select_data_format('fits',ierr)
+ elseif (any((index(extensions, '.vtk') > 0))) then
+    call select_data_format('vtk',ierr)
  elseif (any((index(extensions, '.pb') > 0))) then
     call select_data_format('phantom', ierr)
  elseif (any((index(extensions, '.pbob') > 0))) then

--- a/src/read_data_gadget.f90
+++ b/src/read_data_gadget.f90
@@ -1168,7 +1168,7 @@ end subroutine allocate_temp1
 !!------------------------------------------------------------
 
 subroutine set_labels_gadget
- use labels,        only:label,iamvec,labelvec,labeltype,ix,ivx,ipmass,lenlabel,&
+ use labels,        only:label,iamvec,labelvec,labeltype,ix,ivx,ipmass,lenlabel,set_vector_labels, &
                           ih,irho,ipr,iutherm,iBfirst,iBpol,iBtor,idivB,iax,make_vector_label
  use params
  use settings_data, only:ndim,ndimV,ncolumns,ntypes,UseTypeInRenderings,iformat
@@ -1636,19 +1636,8 @@ subroutine set_labels_gadget
  if (iutherm > 0) label(iutherm)    = 'u'
  if (ipmass > 0)  label(ipmass)     = 'particle mass'
  if (ih > 0)      label(ih)         = 'h'
- !
- !--set labels for vector quantities
- !
- i = 1
- do while (i <= ncolumns)
-    if (iamvec(i) > 0) then
-       tmplabel = label(i)
-       call make_vector_label(tmplabel,i,ndimV,iamvec,labelvec,label,labelcoord(:,1))
-       i = i + ndimV
-    else
-       i = i + 1
-    endif
- enddo
+
+ call set_vector_labels(ncolumns,ndimV,iamvec,labelvec,label,labelcoord(:,1))
 
  call make_vector_label('v',ivx,ndimV,iamvec,labelvec,label,labelcoord(:,1))
  call make_vector_label('a',iax,ndimV,iamvec,labelvec,label,labelcoord(:,1))

--- a/src/read_data_sphNG.f90
+++ b/src/read_data_sphNG.f90
@@ -1380,9 +1380,9 @@ subroutine read_data_sphNG(rootname,indexstart,iposn,nstepsread)
  use mem_allocation, only:alloc
  use system_utils,   only:lenvironment,renvironment
  use labels,         only:ipmass,irho,ih,ix,ivx,labeltype,print_types,headertags,&
-                          iutherm,itemp,ikappa,irhorestframe
+                          iutherm,itemp,ikappa,irhorestframe,labelreq,nreq
  use calcquantities, only:calc_quantities
- use asciiutils,     only:make_tags_unique
+ use asciiutils,     only:make_tags_unique,match_tag
  use sphNGread
  use lightcurve_utils, only:get_temp_from_u,ionisation_fraction,get_opacity
  use read_kepler,      only:check_for_composition_file,read_kepler_composition
@@ -2044,6 +2044,14 @@ subroutine read_data_sphNG(rootname,indexstart,iposn,nstepsread)
              if (tagged) read(iunit,end=33,iostat=ierr) tagtmp
              icolumn = assign_column(tagtmp,iarr,i,6,imaxcolumnread,idustarr,ncolstep)
              if (tagged) tagarr(icolumn) = tagtmp
+             ! force data read if label matches one of the required columns
+             if (.not.required(icolumn)) then
+                if (match_tag(labelreq(1:nreq),tagtmp) > 0) then
+                   print "(1x,a,i2)",'-> found '//trim(tagtmp)//' in column ',icolumn
+                   required(icolumn) = .true.
+                endif
+             endif
+
              if (debug)  print*,' reading real to col:',icolumn,' tag = ',trim(tagtmp), ' required = ',required(icolumn)
              if (required(icolumn)) then
                 if (doubleprec) then

--- a/src/read_data_vtk.f90
+++ b/src/read_data_vtk.f90
@@ -39,12 +39,12 @@ module readdata_vtk
 contains
 
 subroutine read_data_vtk(rootname,istepstart,ipos,nstepsread)
- use particle_data,    only:dat,npartoftype,masstype,maxcol,maxpart
+ use particle_data,    only:dat,npartoftype,masstype,maxcol,maxpart,headervals
  use settings_data,    only:ndim,ndimV,ncolumns,ncalc,ipartialread,iverbose
  use mem_allocation,   only:alloc
- use labels,           only:ih,irho,ipmass
+ use labels,           only:ih,irho,ipmass,headertags
  use system_utils,     only:get_command_option
- use asciiutils,       only:get_value
+ use asciiutils,       only:get_value,numfromfile
  integer, intent(in)                :: istepstart,ipos
  integer, intent(out)               :: nstepsread
  character(len=*), intent(in)       :: rootname
@@ -110,6 +110,13 @@ subroutine read_data_vtk(rootname,istepstart,ipos,nstepsread)
  ipartialread = .false.
  call read_vtk_legacy_binary(trim(datfile),npart,ncolstep,ierr,dat(:,:,i))
  call set_labels_vtk
+
+ ! set header variables from useful information from the file
+ headertags(1) = 'npart'
+ headervals(1,i) = real(npart)
+ headertags(2) = 'nfile'
+ headervals(2,i) = real(numfromfile(datfile))
+
 !
 !--set particle mass and number of particles of type 1
 !
@@ -150,6 +157,7 @@ subroutine read_vtk_header(filename,ndim,ndimV,ncolstep,npart,is_binary,ierr)
  ndim = 3
  ndimV = 3
  ncolstep = 0
+ tagarr(:) = ''
  
  open(newunit=iu,file=filename,status='old',action='read',form='formatted',iostat=ierr)
  if (ierr /= 0) then

--- a/src/read_data_vtk.f90
+++ b/src/read_data_vtk.f90
@@ -1,0 +1,372 @@
+!-----------------------------------------------------------------
+!
+!  This file is (or was) part of SPLASH, a visualisation tool
+!  for Smoothed Particle Hydrodynamics written by Daniel Price:
+!
+!  http://users.monash.edu.au/~dprice/splash
+!
+!  SPLASH comes with ABSOLUTELY NO WARRANTY.
+!  This is free software; and you are welcome to redistribute
+!  it under the terms of the GNU General Public License
+!  (see LICENSE file for details) and the provision that
+!  this notice remains intact. If you modify this file, please
+!  note section 2a) of the GPLv2 states that:
+!
+!  a) You must cause the modified files to carry prominent notices
+!     stating that you changed the files and the date of any change.
+!
+!  Copyright (C) 2023- Daniel Price. All rights reserved.
+!  Contact: daniel.price@monash.edu
+!
+!-----------------------------------------------------------------
+
+!-------------------------------------------------------------------------
+! this subroutine reads from the data file(s)
+! change this to change the format of data input
+!
+! THIS VERSION IS FOR READING VTK FILES
+!
+!-------------------------------------------------------------------------
+module readdata_vtk
+ use params, only:maxplot
+ implicit none
+
+ public :: read_data_vtk, set_labels_vtk
+ character(len=32) :: tagarr(maxplot)
+
+ private
+
+contains
+
+subroutine read_data_vtk(rootname,istepstart,ipos,nstepsread)
+ use particle_data,    only:dat,npartoftype,masstype,maxcol,maxpart
+ use settings_data,    only:ndim,ndimV,ncolumns,ncalc,ipartialread,iverbose
+ use mem_allocation,   only:alloc
+ use labels,           only:ih,irho,ipmass
+ use system_utils,     only:get_command_option
+ use asciiutils,       only:get_value
+ integer, intent(in)                :: istepstart,ipos
+ integer, intent(out)               :: nstepsread
+ character(len=*), intent(in)       :: rootname
+ character(len=len(rootname)+10)    :: datfile
+ integer               :: i,ierr
+ integer               :: ncolstep,npart,nsteps_to_read
+ logical               :: iexist,reallocate,is_binary
+ real, allocatable     :: pmass(:)
+ real :: hfac
+
+ nstepsread = 0
+ nsteps_to_read = 1
+
+ if (len_trim(rootname) > 0) then
+    datfile = trim(rootname)
+ else
+    print*,' **** no data read **** '
+    return
+ endif
+!
+!--check if first data file exists
+!
+ if (iverbose==1 .and. ipos==1) print "(1x,a)",'reading vtk format'
+ inquire(file=datfile,exist=iexist)
+ if (.not.iexist) then
+    !
+    !--append .vtk on the endif not already present
+    !
+    datfile=trim(rootname)//'.vtk'
+    inquire(file=datfile,exist=iexist)
+ endif
+ if (.not.iexist) then
+    print "(a)",' *** error: '//trim(rootname)//': file not found ***'
+    return
+ endif
+!
+!--read data from snapshots
+!
+ i = istepstart
+ write(*,"(23('-'),1x,a,1x,23('-'))") trim(datfile)
+ !
+ !--open file and read header information
+ !
+ call read_vtk_header(trim(datfile),ndim,ndimV,ncolstep,npart,is_binary,ierr)
+ if (ierr > 0) then
+    print*,'ERROR reading vtk file: ierr=',ierr
+    return
+ else
+    print "(1x,a,i0,a,i0)",'npart = ',npart,' ncolumns = ',ncolstep
+ endif
+ !
+ !--allocate or reallocate memory for main data array
+ !
+ ncolumns = ncolstep
+ nstepsread = 1
+ reallocate = (npart > maxpart)
+ if (reallocate .or. .not.(allocated(dat))) then
+    call alloc(npart,nsteps_to_read,max(ncolumns+ncalc,maxcol),mixedtypes=.false.)
+ endif
+!
+!--now memory has been allocated, read main data arrays
+!
+ ipartialread = .false.
+ call read_vtk_legacy_binary(trim(datfile),npart,ncolstep,ierr,dat(:,:,i))
+ call set_labels_vtk
+!
+!--set particle mass and number of particles of type 1
+!
+ if (npart >= 1) then
+    !
+    !--reconstruct particle mass from h and rho
+    !
+    if (ih > 0 .and. irho > 0 .and. ipmass==0) then
+       allocate(pmass(npart))
+       hfac = 1.0
+       pmass = dat(1:npart,irho,i)*(dat(1:npart,ih,i)/hfac)**ndim
+       if (any(abs(pmass - pmass(1)) > 1e-6)) print*,' WARNING: unequal particle masses not supported'
+       !print*,pmass(1:10)
+       masstype(1,i) = pmass(1)
+       deallocate(pmass)
+    else
+       masstype(1,i) = 1./npart
+    endif
+    npartoftype(1,i) = npart
+ endif
+
+end subroutine read_data_vtk
+
+!----------------------------------------------------
+! read header information
+!----------------------------------------------------
+subroutine read_vtk_header(filename,ndim,ndimV,ncolstep,npart,is_binary,ierr)
+ character(len=*)     :: filename
+ integer, intent(out) :: ndim,ndimV,ncolstep,npart,ierr
+ logical, intent(out) :: is_binary
+ character(len=256)   :: version,header
+ character(len=6)     :: fileformat
+ character(len=30)    :: dataset,datatype
+ integer :: iu
+ 
+ ierr = 0
+ npart = 0
+ ndim = 3
+ ndimV = 3
+ ncolstep = 0
+ 
+ open(newunit=iu,file=filename,status='old',action='read',form='formatted',iostat=ierr)
+ if (ierr /= 0) then
+    print*,' ERROR opening '//trim(filename)
+    return
+ endif
+
+ ! read version information from first line
+ read(iu,"(a)",iostat=ierr) version
+ if (ierr /= 0) then
+    print*,' ERROR reading vtk version from first line'
+ endif
+
+ ! read data description from second line
+ read(iu,"(a)",iostat=ierr) header
+ if (ierr /= 0) then
+    print*,' ERROR reading vtk header from second line'
+ else
+    print "(a)",trim(version)//': '//trim(header)
+ endif
+
+ ! read file format from third line
+ is_binary = .false.
+ read(iu,"(a)",iostat=ierr) fileformat
+ if (ierr /= 0) then
+    print*,' ERROR reading vtk file format from third line'
+ else
+    if (trim(fileformat)=='BINARY' .or. trim(fileformat)=='binary') then
+       is_binary = .true.
+    else
+       print "(2x,a)",trim(fileformat)
+    endif
+ endif
+
+ ! read dataset type
+ read(iu,*,iostat=ierr) dataset,datatype
+ if (ierr /= 0) then
+    print*,trim(dataset),trim(datatype)
+    print*,' ERROR reading vtk dataset type ',ierr
+ else
+    if (trim(datatype) /= 'UNSTRUCTURED_GRID') then
+       print "(a)",' ERROR: got '//trim(datatype)//' but splash reader only supports UNSTRUCTURED_GRID'
+       ierr = 1
+       return
+    endif
+ endif
+ close(iu)
+
+ if (is_binary) then
+    call read_vtk_legacy_binary(filename,npart,ncolstep,ierr)
+ else
+    print "(a)",' ERROR: got fileformat='//trim(fileformat)//' but splash reader only supports BINARY'
+ endif
+
+end subroutine read_vtk_header
+
+!----------------------------------------------------
+! read vtk legacy binary format
+!----------------------------------------------------
+subroutine read_vtk_legacy_binary(filename,npart,ncolstep,ierr,dat)
+ use settings_data, only:debugmode
+ use byteswap,      only:bs
+ use labels,        only:iamvec
+ character(len=*), intent(in)  :: filename
+ integer,          intent(out) :: npart,ncolstep,ierr
+ real,             intent(out), optional :: dat(:,:)
+ character(len=32)  :: dataset,datatype,tmp
+ character(len=256) :: line
+ character(len=1)   :: newline
+ real(kind=4), allocatable :: xyz(:,:),rval(:,:)
+ real(kind=8), allocatable :: r8val(:,:)
+ integer :: iu,nline,n,i,nvec,nfields,npts
+
+ ! open the file with stream access and use get_next_line to parse the ascii lines
+ open(newunit=iu,file=filename,status='old',action='read',form='unformatted',iostat=ierr,access='stream')
+ nline = 0
+ ncolstep = 0
+ iamvec(:) = 0
+ do while(ierr == 0)
+    call get_next_line(iu,line,n,nline,ierr)
+
+    ! Process the line as needed, e.g., print it
+    select case (line(1:6))
+    case('POINTS')
+       read(line(1:n),*,iostat=ierr) dataset,npart,datatype
+       !print*,trim(dataset),npart,trim(datatype)
+       allocate(xyz(3,npart),rval(1,npart))
+       read(iu,iostat=ierr) xyz,newline
+       if (present(dat)) then
+          dat(1:npart,1:3) = bs(transpose(xyz)) ! byteswap from big endian -> little
+          !print*,' x vals = ',dat(1:4,1)
+          !print*,' y vals = ',dat(1:4,2)
+          !print*,' z vals = ',dat(1:4,3)
+       endif
+       deallocate(xyz,rval)
+       ncolstep = ncolstep + 3
+    case('FIELD ')
+       nvec = 0
+       read(line(1:n),*,iostat=ierr) tmp,tmp,nfields
+       !print*,' number of fields = ',nfields
+       do i=1,nfields
+          call get_next_line(iu,line,n,nline,ierr)
+          if (ierr /= 0 .or. n < 1) exit
+          read(line(1:n),*,iostat=ierr) tagarr(ncolstep+1),nvec,npts,datatype
+          !print*,'GOT: ',tagarr(ncolstep+1),': nvec=',nvec,'npts=',npts,trim(datatype)
+          select case(trim(datatype))
+          case('float')
+             ! read/convert floats to working precision
+             allocate(rval(nvec,npts))
+             read(iu,iostat=ierr) rval,newline
+             if (debugmode) print*,bs(rval(1,1:min(npts,10)))
+             if (npts==npart) then
+                if (present(dat)) dat(1:npart,ncolstep+1:ncolstep+nvec) = bs(transpose(rval)) ! byteswap from big endian -> little
+                if (nvec > 1) iamvec(ncolstep+1:ncolstep+nvec) = ncolstep
+                ncolstep = ncolstep + nvec
+             else
+                if (present(dat)) print*,'WARNING: skipping float '//trim(tagarr(ncolstep+1))//' as npts /= npart'
+             endif
+             deallocate(rval)
+          case('double')
+             ! read/convert doubles to working precision
+             allocate(r8val(nvec,npts))
+             read(iu,iostat=ierr) r8val,newline
+             if (debugmode) print*,bs(r8val(1,1:min(npts,10)))
+             if (npts==npart) then
+                if (present(dat)) dat(1:npart,ncolstep+1:ncolstep+nvec) = bs(transpose(r8val)) ! byteswap from big endian -> little
+                if (nvec > 1) iamvec(ncolstep+1:ncolstep+nvec) = ncolstep
+                ncolstep = ncolstep + nvec
+             else
+                if (present(dat)) print*,'WARNING: skipping double '//trim(tagarr(ncolstep+1))//' as npts /= npart'
+             endif
+             deallocate(r8val)
+          case('int')
+             ! just silently skip integers
+             allocate(rval(nvec,npts))
+             read(iu,iostat=ierr) rval,newline
+             deallocate(rval)
+          case default
+             if (present(dat)) print*,'Warning: unknown data type '//trim(datatype)//' assuming 4-bytes and skipping'
+             allocate(rval(nvec,npts))
+             read(iu,iostat=ierr) rval,newline
+             deallocate(rval)
+          end select
+       enddo
+    end select
+ enddo
+
+end subroutine read_vtk_legacy_binary
+
+!------------------------------------------------------
+! read a line of ascii text from an unformatted stream
+!------------------------------------------------------
+subroutine get_next_line(iu,line,n,nline,ierr)
+ use settings_data, only:debugmode
+ integer,          intent(in)    :: iu
+ character(len=*), intent(out)   :: line
+ integer,          intent(inout) :: nline
+ integer,          intent(out)   :: n,ierr
+
+ n = 1
+ line = ''
+ do while(n < len(line))
+    read(iu, iostat=ierr) line(n:n)
+    if (ierr /= 0) exit
+    if (line(n:n) == char(10)) exit
+    n = n + 1
+ end do
+ n = n - 1  ! n is the line length
+
+ if (ierr == 0) then
+    nline = nline + 1
+    if (debugmode) print "(a,i2,a)",' DEBUG: ',nline,' : '//trim(line(1:n))
+ endif
+
+end subroutine get_next_line
+
+!------------------------------------------------------------
+! set labels for each column of data
+!------------------------------------------------------------
+subroutine set_labels_vtk
+ use labels,         only:label,labeltype,ix,ipmass,ih,irho,labelvec,iamvec,&
+                          set_vector_labels,label_synonym
+ use settings_data,  only:ndim,ndimV,ntypes,UseTypeInRenderings,ncolumns
+ use geometry,       only:labelcoord
+ integer :: i
+
+ if (ndim <= 0 .or. ndim > 3) then
+    print*,'*** ERROR: ndim = ',ndim,' in set_labels_fits ***'
+    return
+ endif
+ if (ndimV <= 0 .or. ndimV > 3) then
+    print*,'*** ERROR: ndimV = ',ndimV,' in set_labels_fits ***'
+    return
+ endif
+
+ ix(1) = 1
+ ix(2) = 2
+ if (ndim >= 3) ix(3) = 3
+ !ipmass = ndim+3
+ do i=4,ncolumns
+    label(i) = trim(tagarr(i))
+    if (label_synonym(label(i))=='density') irho = i
+    if (label_synonym(label(i))=='h') ih = i
+ enddo
+ call set_vector_labels(ncolumns,ndimV,iamvec,labelvec,label,labelcoord(:,1))
+
+ ! set labels of the quantities read in
+ if (ix(1) > 0)   label(ix(1:ndim)) = labelcoord(1:ndim,1)
+ if (irho > 0)    label(irho)       = 'density'
+ if (ipmass > 0)  label(ipmass)     = 'particle mass'
+ if (ih > 0)      label(ih)         = 'h'
+
+ ! set labels for each particle type
+ ntypes = 1
+ labeltype(1) = 'gas'
+ UseTypeInRenderings(:) = .true.
+
+end subroutine set_labels_vtk
+
+end module readdata_vtk

--- a/src/splash.f90
+++ b/src/splash.f90
@@ -51,6 +51,8 @@ program splash
 !
 !     -------------------------------------------------------------------------
 !     Version history/ Changelog:
+!     3.9.0   : (06/11/23)
+!             implemented vtk reader capable of reading snapshots from Shamrock code
 !     3.8.5   : (23/10/23)
 !             implemented smoothed particle plots with multiple steps per page;
 !             allow for .cols and .comp file in current directory even if the filepath is not the current dir;
@@ -583,7 +585,7 @@ program splash
  character(len=120) :: string,exactfile
  character(len=12)  :: convertformat
  character(len=lenlabel) :: stringx,stringy,stringr,stringc,stringv
- character(len=*), parameter :: version = 'v3.8.5 [23rd Oct 2023]'
+ character(len=*), parameter :: version = 'v3.9.0 [6th Nov 2023]'
 
  !
  ! initialise some basic code variables

--- a/src/splash.f90
+++ b/src/splash.f90
@@ -52,6 +52,9 @@ program splash
 !     -------------------------------------------------------------------------
 !     Version history/ Changelog:
 !     3.9.0   : (06/11/23)
+!             follow-the-label column choice, where if a label is selected for plotting
+!             from the first file, it will automagically shift to find the matching label
+!             in subsequent files, even if the column containing the quantity has changed;
 !             implemented vtk reader capable of reading snapshots from Shamrock code
 !     3.8.5   : (23/10/23)
 !             implemented smoothed particle plots with multiple steps per page;

--- a/src/timestepping.f90
+++ b/src/timestepping.f90
@@ -15,7 +15,7 @@
 !  a) You must cause the modified files to carry prominent notices
 !     stating that you changed the files and the date of any change.
 !
-!  Copyright (C) 2005-2014 Daniel Price. All rights reserved.
+!  Copyright (C) 2005-2023 Daniel Price. All rights reserved.
 !  Contact: daniel.price@monash.edu
 !
 !-----------------------------------------------------------------
@@ -191,11 +191,7 @@ subroutine timestep_loop(ipicky,ipickx,irender,icontourplot,ivecplot)
     endif
  endif
 
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-
  call plot_close
-
- return
 
 end subroutine timestep_loop
 
@@ -280,7 +276,6 @@ recursive subroutine get_nextstep(istep,ilocindat)
     endif
  endif
 
- return
 end subroutine get_nextstep
 
 !-------------------------------------------------------------
@@ -338,14 +333,13 @@ subroutine colour_timestep(istep,iChangeColours,iChangeStyles)
     end select
  endif
 
- return
 end subroutine colour_timestep
 
 !---------------------------------------------------------------------------------------
 ! colours all the particles using the default colour for their type
 !---------------------------------------------------------------------------------------
 subroutine colourparts_default(npartoftype,iamtype)
- use params, only:int1
+ use params,        only:int1
  use settings_data, only:ntypes
  use particle_data, only:icolourme
  use settings_part, only:idefaultcolourtype


### PR DESCRIPTION
trying to plot files with the same quantity in different columns in different files was previously not possible in splash. This pull request implements a simple label-matching scheme that will shift the data column based on the selection made from the initial menu. In this way the data is read seamlessly from both files with the columns automatically matched. Unit rescalings follow the original menu or what is saved in the splash.units file.

This was tested on two phantom snapshots, one with u in column 11 and the other with u in column 12. For this example everything seems to work.