### PR TITLE
Extra columns from separate file via "--extracols" flag

### DIFF
--- a/src/read_data_sphNG.f90
+++ b/src/read_data_sphNG.f90
@@ -66,7 +66,7 @@ module sphNGread
  implicit none
  real(doub_prec) :: udist,umass,utime,umagfd
  real :: tfreefall,dtmax
- integer :: istartmhd,istartrt,nmhd,idivvcol,idivvxcol,icurlvxcol,icurlvycol,icurlvzcol,iHIIcol,iHeIIcol,iHeIIIcol
+ integer :: istartmhd,istartrt,nmhd,idivvcol,idivvxcol,icurlvxcol,icurlvycol,icurlvzcol,iHIIcol,iHeIIcol,iHeIIIcol,iextracols
  integer :: nhydroreal4,istart_extra_real4
  integer :: itempcol = 0
  integer :: ncolstepfirst = 0
@@ -1386,7 +1386,7 @@ subroutine read_data_sphNG(rootname,indexstart,iposn,nstepsread)
  use settings_data,  only:ndim,ndimV,ncolumns,ncalc,required,ipartialread,&
                       lowmemorymode,ntypes,iverbose,ndusttypes
  use mem_allocation, only:alloc
- use system_utils,   only:lenvironment,renvironment
+ use system_utils,   only:lenvironment,renvironment,envlist
  use labels,         only:ipmass,irho,ih,ix,ivx,labeltype,print_types,headertags,&
                           iutherm,itemp,ikappa,irhorestframe,labelreq,nreq
  use calcquantities, only:calc_quantities
@@ -1397,7 +1397,7 @@ subroutine read_data_sphNG(rootname,indexstart,iposn,nstepsread)
  integer, intent(in)  :: indexstart,iposn
  integer, intent(out) :: nstepsread
  character(len=*), intent(in) :: rootname
- integer :: i,j,k,ierr,iunit
+ integer :: i,j,k,ierr,iunit,iu_extra
  integer :: intg1,int2,int3,ilocvx,iversion
  integer :: i1,iarr,i2,iptmass1,iptmass2
  integer :: npart_max,nstep_max,ncolstep,icolumn,idustarr,nptmasstot
@@ -1407,13 +1407,14 @@ subroutine read_data_sphNG(rootname,indexstart,iposn,nstepsread)
  integer :: ipos,nptmass,nptmassi,ndust,nstar,nunknown,ilastrequired
  integer :: imaxcolumnread,nhydroarraysinfile,nhdr,nkilled
  integer :: itype,iphaseminthistype,iphasemaxthistype,nthistype,iloc,idenscol
- integer :: icentre,icomp_col_start,ncomp
+ integer :: icentre,icomp_col_start,ncomp,nextracols
  integer, dimension(maxparttypes) :: npartoftypei
  real,    dimension(maxparttypes) :: massoftypei
  logical :: iexist, doubleprec,imadepmasscolumn,gotbinary,gotiphase
 
  character(len=len(rootname)+10) :: dumpfile,compfile
  character(len=100) :: fileident
+ character(len=30), dimension(10) :: labelextra
 
  integer*8, dimension(maxarrsizes) :: isize
  integer, dimension(maxarrsizes) :: nint,nint1,nint2,nint4,nint8,nreal,nreal4,nreal8
@@ -1436,11 +1437,13 @@ subroutine read_data_sphNG(rootname,indexstart,iposn,nstepsread)
  real, parameter :: Xfrac_default=0.69843,Yfrac_default=0.28731
 
  nstepsread = 0
+ nextracols = 0
  nstep_max = 0
  npart_max = maxpart
  npart = 0
  iunit = 15
  ipmass = 4
+ iextracols = 0
  idivvcol = 0
  idivvxcol = 0
  icurlvxcol = 0
@@ -1486,6 +1489,8 @@ subroutine read_data_sphNG(rootname,indexstart,iposn,nstepsread)
  get_kappa_tot = lenvironment("SPLASH_GET_KAPPATOT")
  get_kappa = lenvironment("SPLASH_GET_KAPPA") .or. get_kappa_tot
  get_ionfrac = lenvironment("SPLASH_GET_ION")
+ call envlist('SPLASH_EXTRACOLS',nextracols,labelextra)
+
  if ((get_temperature .or. get_kappa) .and. itempcol > 0 .and. required(itempcol)) then
     required(irho) = .true.
     required(irhorestframe) = .true.
@@ -1744,6 +1749,11 @@ subroutine read_data_sphNG(rootname,indexstart,iposn,nstepsread)
              ncolstepfirst = ncolstep   !  save number of columns
           elseif (ncolstep < ncolstepfirst) then
              ncolstep = ncolstepfirst   !  used saved number of columns
+          endif
+          if (nextracols > 0) then
+             print "(a,i2,a)",' READING ',nextracols,' EXTRA COLUMNS '
+             iextracols = ncolstep + 1
+             ncolstep = ncolstep + nextracols
           endif
           inquire(file=trim(dumpfile)//'.divv',exist=iexist)
           if (iexist) then
@@ -2217,6 +2227,22 @@ subroutine read_data_sphNG(rootname,indexstart,iposn,nstepsread)
        close(66)
     endif
  endif
+ !
+ !--read extra columns for phantom dumps
+ !
+ if (phantomdump .and. iextracols /= 0) then
+    do i=1,nextracols
+       print "(a)",' reading extra columns from '//trim(dumpfile)//'.'//trim(labelextra(i))//'.extras'
+       open(newunit=iu_extra,file=trim(dumpfile)//'.'//trim(labelextra(i))//'.extras',form='unformatted',status='old',iostat=ierr)
+       if (ierr /= 0) then
+          print "(a)",' ERROR opening '//trim(dumpfile)//'.'//trim(labelextra(i))//'.extras'
+       else
+          read(iu_extra,iostat=ierr) dat(1:ntotal,iextracols+i-1,j)
+          if (ierr /= 0) print "(a)",' WARNING: ERRORS reading extra columns from file'
+          close(iu_extra)
+       endif
+    enddo
+endif
 
  if (icomp_col_start > 0 .and. any(required(icomp_col_start:icomp_col_start+ncomp))) then
     call read_kepler_composition(compfile,ntotal,dat(:,:,j),icomp_col_start,ncomp)
@@ -2573,11 +2599,12 @@ subroutine set_labels_sphNG
                            get_nearest_mass_unit,get_nearest_velocity_unit
  use sphNGread
  use asciiutils,      only:lcase,make_tags_unique,match_tag
- use system_utils,    only:lenvironment,get_environment_or_flag
- integer :: i,j,idustlast
+ use system_utils,    only:lenvironment,get_environment_or_flag,envlist
+ integer :: i,j,idustlast,nextracols
  real(doub_prec)   :: unitx,unitvel,unitmass
  character(len=20) :: string,unitlabelx,unitlabelv
  character(len=20) :: deltav_string
+ character(len=30), dimension(10) :: labelextra
 
  if (ndim <= 0 .or. ndim > 3) then
     print*,'*** ERROR: ndim = ',ndim,' in set_labels_sphNG ***'
@@ -2756,6 +2783,14 @@ subroutine set_labels_sphNG
  if (iHIIcol > 0) label(iHIIcol) = 'HII fraction'
  if (iHeIIcol > 0) label(iHeIIcol) = 'HeII fraction'
  if (iHeIIIcol > 0) label(iHeIIIcol) = 'HeIII fraction'
+
+ ! Labels for extra columns
+ call envlist('SPLASH_EXTRACOLS',nextracols,labelextra)
+ if (nextracols > 0) then
+    do i=iextracols,iextracols+nextracols-1
+       label(i) = trim(labelextra(i-iextracols+1))
+    enddo
+ endif
  if (icurlvxcol > 0 .and. icurlvycol > 0 .and. icurlvzcol > 0) then
     call make_vector_label('curl v',icurlvxcol,ndimV,iamvec,labelvec,label,labelcoord(:,1))
  endif


### PR DESCRIPTION
For a long time, particle quantities computed outside splash have been read through a "hack" where they are disguised as "divv" columns. These changes aim for a proper implementation and here is a summary:
- For a dump file `dump_01234`, an extra quantity, e.g. `etot`, can be written to a separate unformatted file of the form `dump_01234.etot.extras`.
- This file is read using the `--extracols` flag, e.g., `splash dump_01234 --extracols=etot`. For more than one extra quantity, stored in separate .extra files, a comma-separated list can be provided to `--extracols`. The corresponding environment variable is `SPLASH_EXTRACOLS`.
- The extra column will appear as, following the example, `etot`, in splash.

Other than being a proper implementation, compared to the "divv hack", this implementation allows arbitrarily many extra columns to be read (instead of just four), and properly labels the extra columns and so the user doesn't forget what quantities were calculated in a ".divv file". With these changes, we could also probably get rid of code that is specific for reading divv and curlv data.