### PR TITLE
Increased character length for copyright in system_utils

### DIFF
--- a/src/system_utils.f90
+++ b/src/system_utils.f90
@@ -445,7 +445,7 @@ end subroutine get_user
 !--get copyright string involving logged in user and current year
 !
 function get_copyright() result(string)
- character(len=30) :: string
+ character(len=40) :: string
  character(len=8) :: year
 
  call get_user(string)


### PR DESCRIPTION
Issue was in Hollywood mode. My name was too long for the copyright line and would cut the end off. Just increased the character length by 10 for the string in the copyright line.

![splash_hw_name_cutoff](https://github.com/user-attachments/assets/faeb21fb-b309-4e02-a96d-e1c54f9519e8)
![splash_hw_name_cutoff_fix](https://github.com/user-attachments/assets/fd51fd24-f48d-427e-b615-65c9cb3030cc)

