### PR TITLE
(lightcurve) include sink particles in SED calculation if Teff and Reff are set and rendersinks=T

### DIFF
--- a/src/analysis.f90
+++ b/src/analysis.f90
@@ -403,10 +403,11 @@ subroutine open_analysis(analysistype,required,ncolumns,ndim,ndimV,nsinks)
 
  case('lightcurve')
     !
-    !--for lightcurve need to h, mass and utherm
+    !--for lightcurve need h, mass, density, temperature and opacity
     !
     required(ix(1:ndim)) = .true.
     required(ih) = .true.
+    required(irho) = .true.
     required(iutherm) = .true.
     required(ipmass) = .true.
     required(itemp) = .true.

--- a/src/interpolate3D_opacity.f90
+++ b/src/interpolate3D_opacity.f90
@@ -104,7 +104,7 @@ subroutine interp3D_proj_opacity(x,y,z,pmass,npmass,hh,weight,dat,zorig,itype,np
  real :: term,dy,dy2,ypix,zfrac,hav,zcutoff
  real :: xpixmin,xpixmax,xmax,ypixmin,ypixmax,ymax
  real :: hmin,hminall,dfac,pixwidthz,pixint,zi,xpixi,zpix
- real :: fopacity,tau,rkappatemp,xi,yi
+ real :: fopacity,tau,tau_before,rkappatemp,xi,yi
  real :: t_start,t_end,t_used
  logical :: adjustzperspective,rendersink
  real, dimension(npixx) :: xpix,dx2i
@@ -217,7 +217,7 @@ subroutine interp3D_proj_opacity(x,y,z,pmass,npmass,hh,weight,dat,zorig,itype,np
 !$omp private(hi1,hi21,hsmooth,term,dati,datvi,pixwidthz) &
 !$omp private(ipixmin,ipixmax,jpixmin,jpixmax,xpixmin,xpixmax,ypixmin,ypixmax) &
 !$omp private(dx2i,q2,xpixi,ypix,zpix,dy,dy2,wab,dfac,pixint) &
-!$omp private(ipart,i,ipix,jpix,tau,fopacity) &
+!$omp private(ipart,i,ipix,jpix,tau,tau_before,fopacity) &
 !$omp reduction(+:nused,nsink,nsubgrid,nok) &
 !$omp reduction(min:hminall)
 !!$omp do ordered schedule(dynamic)
@@ -386,13 +386,16 @@ subroutine interp3D_proj_opacity(x,y,z,pmass,npmass,hh,weight,dat,zorig,itype,np
                 wab = pixint*dfac
 
                 tau = wab*term
-                tausmooth(ipix,jpix) = tausmooth(ipix,jpix) + tau
+                tau_before = tausmooth(ipix,jpix)
+                tausmooth(ipix,jpix) = tau_before + tau
                 !
                 !--render, obscuring previously drawn pixels by relevant amount
                 !  also calculate total optical depth for each pixel
                 !
                 if (backwards) then
-                   fopacity = exp(-tausmooth(ipix,jpix))*tau
+                   ! line below correctly handles the case where a particle is highly optically thick
+                   ! and reduces to exp(-tau_before)*tau when the opacity is small, matching forward rendering
+                   fopacity = exp(-tau_before)*(1. - exp(-tau))
                    datsmooth(ipix,jpix) = datsmooth(ipix,jpix) + fopacity*dati
                    if (present(datv)) datvpix(:,ipix,jpix) = datvpix(:,ipix,jpix) + fopacity*datvi(:)
                    if (present(badpix)) then
@@ -412,13 +415,14 @@ subroutine interp3D_proj_opacity(x,y,z,pmass,npmass,hh,weight,dat,zorig,itype,np
                    wab = wfromtable(q2)
 
                    tau = wab*term
-                   tausmooth(ipix,jpix) = tausmooth(ipix,jpix) + tau
+                   tau_before = tausmooth(ipix,jpix)
+                   tausmooth(ipix,jpix) = tau_before + tau
                    !
                    !--render, obscuring previously drawn pixels by relevant amount
                    !  also calculate total optical depth for each pixel
                    !
                    if (backwards) then
-                      fopacity = exp(-tausmooth(ipix,jpix))*tau
+                      fopacity = exp(-tau_before)*(1. - exp(-tau))
                       datsmooth(ipix,jpix) = datsmooth(ipix,jpix) + fopacity*dati
                       if (present(datv)) datvpix(:,ipix,jpix) = datvpix(:,ipix,jpix) + fopacity*datvi(:)
                       if (present(badpix)) then

--- a/src/lightcurve.f90
+++ b/src/lightcurve.f90
@@ -47,12 +47,13 @@ contains
 !---------------------------------------------------------
 subroutine get_lightcurve(ncolumns,dat,npartoftype,masstype,itype,ndim,ntypes,&
                           lum,rphoto,temp,lum_bb,r_bb,Tc,badfrac,specfile,ierr)
- use labels,                only:ix,ih,irho,ipmass,itemp,ikappa,ivx,ipmomx
+ use labels,                only:ix,ih,irho,ipmass,itemp,ikappa,ivx,ipmomx,get_sink_type
  use limits,                only:lim,get_particle_subset
  use lightcurve_utils,      only:get_temp_from_u
  use interpolate3D_opacity, only:interp3D_proj_opacity
+ use kernels,               only:radkernel
  use particle_data,         only:icolourme
- use interpolation,         only:get_n_interp,set_interpolation_weights
+ use interpolation,         only:get_n_interp,set_interpolation_weights,weight_sink
  use settings_data,         only:iRescale,iverbose,required,UseTypeInRenderings,ndimV
  use settings_part,         only:iplotpartoftype
  use settings_render,       only:npix,inormalise=>inormalise_interpolations,&
@@ -63,7 +64,7 @@ subroutine get_lightcurve(ncolumns,dat,npartoftype,masstype,itype,ndim,ntypes,&
  use filenames,             only:tagline
  use blackbody,             only:B_nu,logspace,Wien_nu_from_T,nu_to_lam,&
                                  integrate_log,get_colour_temperature
- use settings_xsecrot,      only:anglex,angley,anglez,taupartdepth
+ use settings_xsecrot,      only:anglex,angley,anglez,taupartdepth,rendersinks
  use rotation,              only:rotate_particles
  use system_utils,          only:get_command_flag,renvironment
  use readwrite_fits,        only:write_fits_cube,write_fits_image,write_fits_image
@@ -78,12 +79,13 @@ subroutine get_lightcurve(ncolumns,dat,npartoftype,masstype,itype,ndim,ntypes,&
  integer :: n,isinktype,npixx,npixy,j,i,nfreq
  integer, parameter :: iu1 = 45
  real, dimension(3) :: xmin,xmax
- real, dimension(:),   allocatable :: weight,x,y,z,flux,opacity
+ real, dimension(:),   allocatable :: weight,x,y,z,h,flux,opacity
  real, dimension(:),   allocatable :: freq,spectrum,bb_spectrum
  real, dimension(:,:), allocatable :: img,taupix,flux_nu,v_on_c,badpix
  real, dimension(:,:,:), allocatable :: img_nu,img_tmp
  real :: zobs,dzobs,dx,dy,area,freqmin,freqmax,lam_max,freq_max,bb_scale,opacity_factor,f_col
  real :: betaz,lorentz,doppler_factor,doppler_factor_max,tempi,badarea
+ real :: rstar,lstar
  logical :: relativistic
 
  lum = 0.
@@ -120,8 +122,8 @@ subroutine get_lightcurve(ncolumns,dat,npartoftype,masstype,itype,ndim,ntypes,&
  !--set number of particles to use in the interpolation routines
  !  and allocate memory for weights
  !
- n = get_n_interp(ntypes,npartoftype,UseTypeInRenderings,iplotpartoftype,size(itype),.false.)
- allocate(weight(n),x(n),y(n),z(n),flux(n),opacity(n),stat=ierr)
+ n = get_n_interp(ntypes,npartoftype,UseTypeInRenderings,iplotpartoftype,size(itype),rendersinks)
+ allocate(weight(n),x(n),y(n),z(n),flux(n),opacity(n),h(n),stat=ierr)
  if (ierr /= 0) then
     print*,' ERROR allocating memory for interpolation weights, aborting...'
     ierr = 3
@@ -130,6 +132,7 @@ subroutine get_lightcurve(ncolumns,dat,npartoftype,masstype,itype,ndim,ntypes,&
  x(1:n) = dat(1:n,ix(1))
  y(1:n) = dat(1:n,ix(2))
  z(1:n) = dat(1:n,ix(3))
+ h(1:n) = dat(1:n,ih)
 
  if (relativistic) then
     allocate(v_on_c(3,n),stat=ierr)
@@ -149,7 +152,7 @@ subroutine get_lightcurve(ncolumns,dat,npartoftype,masstype,itype,ndim,ntypes,&
  dx = (xmax(1)-xmin(1))/npixx
  npixy = int((xmax(2)-xmin(2) - 0.5*dx)/dx) + 1
  dy = (xmax(2)-xmin(2))/npixy
- print "(a,i0,a,i0,a)",' Using ',npixx,' x ',npixy,' pixels'
+ print "(3(a,i0),a)",' Ray-tracing ',n,' particles -> ',npixx,' x ',npixy,' pixel image'
  print "(2(1x,a,es10.3,'->',es10.3,a,/))",'x = [',xmin(1),xmax(1),']','y = [',xmin(2),xmax(2),']'
  !
  !--allocate memory for image
@@ -159,10 +162,10 @@ subroutine get_lightcurve(ncolumns,dat,npartoftype,masstype,itype,ndim,ntypes,&
  !
  !--set interpolation weights (w = m/(rho*h^ndim)
  !
- isinktype = 0 !get_sink_type(ntypes)
+ isinktype = get_sink_type(ntypes)
  call set_interpolation_weights(weight,dat,itype,(iplotpartoftype .and. UseTypeInRenderings),&
       n,npartoftype,masstype,ntypes,ncolumns,irho,ipmass,ih,ndim,iRescale,&
-      idensityweightedinterpolation,inormalise,units,unit_interp,required,.false.,isinktype)
+      idensityweightedinterpolation,inormalise,units,unit_interp,required,rendersinks,isinktype)
  !
  !--set default mask and apply range restrictions to data
  !
@@ -198,6 +201,12 @@ subroutine get_lightcurve(ncolumns,dat,npartoftype,masstype,itype,ndim,ntypes,&
  doppler_factor = 1.
  opacity_factor = 1.
  doppler_factor_max = 0.
+ !$omp parallel do default(none) &
+ !$omp shared(n,nfreq,freq,flux,flux_nu,dat,h,weight,radkernel) &
+ !$omp shared(opacity,relativistic,v_on_c,itemp,f_col) &
+ !$omp private(i,betaz,lorentz,tempi,rstar,lstar) &
+ !$omp firstprivate(opacity_factor,doppler_factor) &
+ !$omp reduction(max:doppler_factor_max)
  do i=1,n
     if (relativistic .and. allocated(v_on_c)) then
        betaz = 1. + v_on_c(3,i)
@@ -207,10 +216,24 @@ subroutine get_lightcurve(ncolumns,dat,npartoftype,masstype,itype,ndim,ntypes,&
        doppler_factor_max = max(doppler_factor,doppler_factor_max)
     endif
     opacity(i) = opacity(i)*opacity_factor
-    tempi = dat(i,itemp)*f_col
+    if (abs(weight(i) - weight_sink) < tiny(0.)) then
+       tempi = dat(i,itemp)
+       print "(a,1pg10.3,a)",' => Using sink particle: Teff = ',tempi,' K'
+       if (opacity(i) < tiny(0.)) then
+          print "(a)",' WARNING: opacity is <=0 for sink, setting to 0.35 cm^2/g'
+          opacity(i) = 0.35
+       endif
+       rstar = h(i)
+       h(i) = rstar / radkernel
+       lstar = 4.*pi*rstar**2*steboltz*tempi**4
+       print "(a,2(es10.3,a),/)",' Luminosity of sink = ',lstar,' erg/s = ',lstar/Lsun,' L_sun'
+    else
+       tempi = dat(i,itemp)*f_col
+    endif
     !call get_opacity_nongrey(nfreq,freq,dat(i,temp),dat(i,rho),opacity_nu(:,i))
     flux_nu(:,i) = B_nu(tempi,freq*doppler_factor)
  enddo
+ !$omp end parallel do
  if (relativistic) print*,' max relativistic correction=',doppler_factor_max
 
  if (allocated(img_nu)) deallocate(img_nu)
@@ -221,7 +244,7 @@ subroutine get_lightcurve(ncolumns,dat,npartoftype,masstype,itype,ndim,ntypes,&
  zobs = huge(zobs)  ! no 3D perspective
  dzobs = 0.
  call interp3D_proj_opacity(x,y,z,&
-      dat(1:n,ipmass),n,dat(1:n,ih),weight, &
+      dat(1:n,ipmass),n,h,weight, &
       flux,z,icolourme(1:n), &
       n,xmin(1),xmin(2),img,taupix,npixx,npixy,&
       dx,dy,zobs,dzobs,opacity,huge(zobs),iverbose,.false.,datv=flux_nu,datvpix=img_nu,badpix=badpix)

--- a/src/read_data_sphNG.f90
+++ b/src/read_data_sphNG.f90
@@ -1278,9 +1278,12 @@ end subroutine set_sink_density
 !----------------------------------------------------------------------
 !  Map sink particle data to splash columns
 !----------------------------------------------------------------------
-integer function map_sink_property_to_column(k,ilocvx,ncolmax) result(iloc)
- use labels, only:ix,ipmass,ih,ivx
+integer function map_sink_property_to_column(k,ilocvx,ncolmax,tag) result(iloc)
+ use labels,     only:ix,ipmass,ih,ivx,itemp,label
+ use asciiutils, only:lcase,match_tag
  integer, intent(in) :: k,ilocvx,ncolmax
+ character(len=*), intent(in) :: tag
+ integer :: iTdust
 
  select case(k)
  case(1:3)
@@ -1296,6 +1299,21 @@ integer function map_sink_property_to_column(k,ilocvx,ncolmax) result(iloc)
        iloc = 0
     endif
  end select
+
+ ! if column not found by index, try to match by tag
+ if (iloc==0) then
+    select case(trim(lcase(tag)))
+    case('teff')
+       ! map Teff into temperature column if it exists
+       if (itemp > 0) then
+          iloc = itemp
+       else ! otherwise map Teff into Tdust column if it exists
+          iTdust = match_tag(label,'Tdust')
+          if (iTdust > 0) iloc = iTdust
+       endif
+    end select
+ endif
+
  if (iloc > ncolmax) iloc = 0  ! error occurred
 
 end function map_sink_property_to_column
@@ -2008,7 +2026,7 @@ subroutine read_data_sphNG(rootname,indexstart,iposn,nstepsread)
                       read(iunit,end=33,iostat=ierr) dattemp(1:isize(iarr))
                       if (ierr /= 0) print*,' ERROR during read of sink particle data, array ',k
 
-                      iloc = map_sink_property_to_column(k,ilocvx,size(dat(1,:,j)))
+                      iloc = map_sink_property_to_column(k,ilocvx,size(dat(1,:,j)),tagtmp)
                       if (iloc > 0) then
                          do i=1,int(isize(iarr),kind=kind(i))
                             dat(npart+i,iloc,j) = real(dattemp(i))
@@ -2019,6 +2037,13 @@ subroutine read_data_sphNG(rootname,indexstart,iposn,nstepsread)
                             if (abs(dat(npart+i,ih,j)) < tiny(0.)) then
                                dat(npart+i,ih,j) = real(dattemp(i))
                                if (i == 1) print*,'zero accretion radius: taking sink particle radius from softening length'
+                            endif
+                         enddo
+                      elseif (trim(tagtmp)=='Reff' .and. ih > 0) then
+                         do i=1,int(isize(iarr),kind=kind(i))
+                            if (dattemp(i) > dat(npart+i,ih,j)) then
+                               dat(npart+i,ih,j) = real(dattemp(i))
+                               print "(a,1pg10.3,a,i0)",' => setting h to Reff = ',dattemp(i),' for sink particle ',npart+i
                             endif
                          enddo
                       else
@@ -2039,7 +2064,7 @@ subroutine read_data_sphNG(rootname,indexstart,iposn,nstepsread)
                       read(iunit,end=33,iostat=ierr) dattempsingle(1:isize(iarr))
                       if (ierr /= 0) print*,' ERROR during read of sink particle data, array ',k
 
-                      iloc = map_sink_property_to_column(k,ilocvx,size(dat(1,:,j)))
+                      iloc = map_sink_property_to_column(k,ilocvx,size(dat(1,:,j)),tagtmp)
                       if (iloc > 0) then
                          do i=1,int(isize(iarr),kind=kind(i))
                             dat(npart+i,iloc,j) = real(dattempsingle(i))


### PR DESCRIPTION
means we can compute a lightcurve with extinction from material in front of stars. For this to work, it requires Teff and Reff to be set in the sink particle properties.

Each sink then emits a blackbody spectrum with the corresponding Teff and Reff which is used in the lightcurve calculation.