### PR TITLE
(build) compile without warnings with gfortran v16

### DIFF
--- a/src/convert_grid.f90
+++ b/src/convert_grid.f90
@@ -737,7 +737,7 @@ subroutine get_splash2grid_options(ndim,ncolstogrid,icoltogrid,isperiodic,xlab)
  integer, intent(in)  :: ndim
  integer, intent(out) :: ncolstogrid,icoltogrid(:)
  logical, intent(out) :: isperiodic(3)
- character(len=1), intent(in) :: xlab(3)
+ character(len=*), intent(in) :: xlab(3)
  integer :: nstring,i,icol
  logical :: dens_only
  character(len=30), dimension(12) :: strings

--- a/src/labels.f90
+++ b/src/labels.f90
@@ -284,9 +284,9 @@ end function get_z_coord
 !
 !-----------------------------------------------------------------
 elemental function strip_units(string,unitslab)
- character(len=lenlabel), intent(in) :: string
- character(len=*),        intent(in) :: unitslab
- character(len=lenlabel)             :: strip_units
+ character(len=*), intent(in) :: string
+ character(len=*), intent(in) :: unitslab
+ character(len=lenlabel) :: strip_units
  integer :: ipos
 
  strip_units = string
@@ -310,9 +310,9 @@ end function strip_units
 !-----------------------------------------------------------------
 elemental function shortstring(string,unitslab)
  use asciiutils, only:string_delete
- character(len=lenlabel), intent(in)           :: string
- character(len=*),        intent(in), optional :: unitslab
- character(len=lenlabel)                       :: shortstring
+ character(len=*), intent(in)           :: string
+ character(len=*), intent(in), optional :: unitslab
+ character(len=lenlabel) :: shortstring
 
  shortstring = string
  !--strip off the units label

--- a/src/labels.f90
+++ b/src/labels.f90
@@ -337,9 +337,9 @@ end function shortstring
 !-----------------------------------------------------------------
 elemental function shortlabel(string,unitslab,lc)
  use asciiutils, only:string_delete,lcase
- character(len=lenlabel), intent(in)           :: string
- character(len=*),        intent(in), optional :: unitslab
- character(len=lenlabel)                       :: shortlabel
+ character(len=*), intent(in)           :: string
+ character(len=*), intent(in), optional :: unitslab
+ character(len=lenlabel)                :: shortlabel
  logical, intent(in), optional :: lc
 
  if (present(unitslab)) then

--- a/src/read_data_dragon.f90
+++ b/src/read_data_dragon.f90
@@ -753,7 +753,7 @@ subroutine find_weights(out_unit_interp,out_unitzintegration,out_labelzintegrati
 
  real(doub_prec), intent(out)      :: out_unit_interp
  real, intent(out)                 :: out_unitzintegration
- character(len=20), intent(out)    :: out_labelzintegration
+ character(len=*), intent(out)     :: out_labelzintegration
  real(doub_prec)                   :: dm_unit, dh_unit, drho_unit, dr_unit
  logical                           :: do_dimweight, do_zintegration
  character(len=20)                 :: rho_length_label


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of longer text labels during grid conversion to prevent unintended truncation.
  * Enhanced label text processing to accept a wider range of string lengths consistently.
  * Updated integration unit-label handling to avoid fixed-length limits, preserving full label text in the output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->